### PR TITLE
Add ktlint build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Run the tests with Gradle:
 gradle test
 ```
 
+Check formatting with ktlint:
+
+```bash
+gradle ktlintCheck
+```
+
 The application can be started with:
 
 ```bash

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.spring)
     alias(libs.plugins.kotlin.jpa)
+    alias(libs.plugins.ktlint.gradle)
 }
 
 java {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ junit-jupiter = "5.12.1"
 kotlin = "2.1.20"
 spring-boot = "3.2.5"
 spring-dep-mgmt = "1.1.4"
+ktlint-gradle = "12.1.1"
 
 [libraries]
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
@@ -13,3 +14,4 @@ kotlin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotl
 kotlin-jpa = { id = "org.jetbrains.kotlin.plugin.jpa", version.ref = "kotlin" }
 spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }
 spring-dependency-management = { id = "io.spring.dependency-management", version.ref = "spring-dep-mgmt" }
+ktlint-gradle = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint-gradle" }


### PR DESCRIPTION
## Summary
- enable ktlint-gradle plugin via version catalog
- apply plugin to `app` module
- document ktlint step in README

## Testing
- `gradle test` *(fails: Plugin not found - offline)*

------
https://chatgpt.com/codex/tasks/task_e_685da2f80f24832e9535a5fe619fd0f2